### PR TITLE
A small change to allow "eating" of parsed arguments.

### DIFF
--- a/lib/micro-optparse/parser.rb
+++ b/lib/micro-optparse/parser.rb
@@ -63,6 +63,7 @@ class Parser
         @optionparser.order!(arguments)
       else
         @optionparser.parse!(arguments)
+      end
     rescue OptionParser::ParseError => e
       puts e.message ; exit(1)
     end


### PR DESCRIPTION
I love your micro-option parser!  The one small change I wanted was to optionally be able to eat the parsed arguments.  This makes it easy to pass in ARGV and be left with a simple file list to then use as input in a very unix sort of way

   ./tool --option=foo file1.txt

for example.

Thanks for your gem, it really is a pleasure to use.
