### PR TITLE
Always returning a short character in short_from

### DIFF
--- a/lib/micro-optparse/parser.rb
+++ b/lib/micro-optparse/parser.rb
@@ -18,6 +18,7 @@ class Parser
       next if @used_short.include?(c) || c == "_"
       return c # returns from short_from method
     end
+    return name.to_s.chars.first
   end
 
   def validate(options) # remove this method if you want fewer lines of code and don't need validations


### PR DESCRIPTION
The function short_from(name) give a character to use as a short option form. 
There was a bug is all the characters were already used: the function would 
then return the full name.

So for instance, in
   options = Parser.new do |p|
     p.option :a, "a"
     p.option :b, "b"
     p.option :ab, "ab"
   end.process! short_from("ab") would return "ab", which mean that the call
to OptParse would look like
   p.on("-ab", "--ab", "ab")... This create an option --ab whose short form
is -a and which needs a mandatory argument b
(and passing --help give something like
-a --abb ab because we ask for a mandatory argument b)

This commit changes short_from to return the first letter if all are taken. 
In this case, the call to OptParse is
   p.on("-a", "--ab", "ab")... which means that the previous short form -a
for --a is overrided but has no other ill-effects.

Note: in opt parse, the last defined short form win, except that p.on have 
more priority. In particular, if both '-v' and '-V' short form are taken, 
then the call to
     short = @used_short.include?("v") ? "-V" : "-v"
     p.on_tail(short, "--version", "Print version") in microoptparse will not
override these switch for the --version option which is what we want.
