### PR TITLE
Move "Parser" into Micro::Optparse namespace to avoid conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Talk in code!
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
    p.banner = "This is a fancy script, for usage see below"
    p.version = "fancy script 0.0 alpha"
    p.option :severity, "set severity", :default => 4, :value_in_set => [4,5,6,7,8]
@@ -75,7 +75,7 @@ To show some example calls and results, I will use a simplified version of the P
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
    p.option :severity, "set severity", :default => 4, :value_in_set => [4,5,6,7,8]
    p.option :mutation, "set mutation", :default => "MightyMutation", :value_matches => /Mutation/
    p.option :plus_selection, "use plus-selection if set", :default => true, :optional => true
@@ -98,7 +98,7 @@ In addition, you don't need to specify all options at once, i.e. you can pass th
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-parser = Parser.new
+parser = Micro::Optparse::Parser.new
 parser.option :eat_snickers, "How many?", :default => 0
 options1 = parser.process!(["--eat-snickers", "2"])
 options2 = parser.process!(["--eat-snickers", "1"])
@@ -133,7 +133,7 @@ Consider the following example to implement mandatory arguments yourself:
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.option :meal, "Choose Meal", :default => "CucumberSalad"
 end.parse!
 
@@ -157,7 +157,7 @@ For example if you want to accept multiple file names with whitespaces in them:
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.option :filenames, "Files which will be processed", :default => []
 end.process!
 
@@ -175,7 +175,7 @@ Yes and No. The literal answer to this question is "No", since a default value m
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.option :file, "File to process (optional)", :default => "String", :optional => true
 end.process!
 
@@ -198,7 +198,7 @@ For example to disable short accessors for all arguments:
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-options = Parser.new(:no_short => true) do |p|
+options = Micro::Optparse::Parser.new(:no_short => true) do |p|
   p.option :foo, "Foo"
 end.process!
 
@@ -211,7 +211,7 @@ To disable short accessor of just a few arguments:
 require 'rubygems' # necessary for ruby v1.8.*
 require 'micro-optparse'
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.option :foo, "Foo without short", :no_short => true
   p.option :bar, "Bar with short"
 end.process!

--- a/lib/micro-optparse.rb
+++ b/lib/micro-optparse.rb
@@ -1,1 +1,1 @@
-require 'micro-optparse/parser'
+require_relative './micro-optparse/parser'

--- a/lib/micro-optparse/parser.rb
+++ b/lib/micro-optparse/parser.rb
@@ -1,7 +1,8 @@
 require 'optparse'
 
-class Parser
+class Micro::Optparse::Parser
   attr_accessor :banner, :version
+
   def initialize(default_settings = {})
     @options = []
     @used_short = []

--- a/lib/micro-optparse/parser.rb
+++ b/lib/micro-optparse/parser.rb
@@ -46,7 +46,7 @@ class Parser
         @used_short << short = o[:settings][:no_short] ? nil : o[:settings][:short] || short_from(o[:name])
         @result[o[:name]] = o[:settings][:default] || false unless o[:settings][:optional] # set default
         name = o[:name].to_s.gsub("_", "-")
-        klass = o[:settings][:default].class == Fixnum ? Integer : o[:settings][:default].class
+        klass = o[:settings][:default].is_a?(Integer) ? Integer : o[:settings][:default].class
 
         args = [o[:description]]
         args << "-" + short if short

--- a/lib/micro-optparse/parser.rb
+++ b/lib/micro-optparse/parser.rb
@@ -70,8 +70,12 @@ class Parser
     rescue OptionParser::ParseError => e
       puts e.message ; exit(1)
     end
-    
+
     validate(@result) if self.respond_to?("validate")
     @result
+  end
+
+  def help!
+    process! %w(--help)
   end
 end

--- a/micro-optparse.gemspec
+++ b/micro-optparse.gemspec
@@ -18,6 +18,5 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   
   s.license = "MIT"
-  s.has_rdoc = false
   s.add_development_dependency("rspec")
 end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -6,9 +6,9 @@ RSpec.configure do |config|
   end
 end
 
-describe Parser do
+describe Micro::Optparse::Parser do
   before(:all) do
-    @evolutionary_algorithm_parser = Parser.new do |p|
+    @evolutionary_algorithm_parser = Micro::Optparse::Parser.new do |p|
       p.option :severity, "set severity", :default => 4, :value_in_set => [4,5,6,7,8]
       p.option :verbose, "enable verbose output"
       p.option :mutation, "set mutation", :default => "MightyMutation", :value_matches => /Mutation/
@@ -35,7 +35,7 @@ describe Parser do
     end
 
     it "should not return a default value if the argument is declared optional" do
-      parser = Parser.new do |p|
+      parser = Micro::Optparse::Parser.new do |p|
         p.option :optarg, "optional argument", :optional => true
       end
       result = parser.process!()
@@ -93,21 +93,21 @@ describe Parser do
 
   describe "empty parser" do
     it "should be allowed to create a parser with an empty block" do
-      parser = Parser.new { }
+      parser = Micro::Optparse::Parser.new { }
       expect(parser).not_to be_nil
-      expect(parser.class).to eql Parser
+      expect(parser.class).to eql Micro::Optparse::Parser
     end
 
     it "should be allowed to create a parser without a block" do
-      parser = Parser.new
+      parser = Micro::Optparse::Parser.new
       expect(parser).not_to be_nil
-      expect(parser.class).to eql Parser
+      expect(parser.class).to eql Micro::Optparse::Parser
     end
   end
 
   describe "parsing of lists" do
     it "should parse list of arguments separated by comma when given an array as default" do
-      parser = Parser.new do |p|
+      parser = Micro::Optparse::Parser.new do |p|
         p.option :listarg, "List Argument", :default => []
       end
 
@@ -116,7 +116,7 @@ describe Parser do
     end
 
     it "should allow multiple argument lists" do
-      parser = Parser.new do |p|
+      parser = Micro::Optparse::Parser.new do |p|
         p.option :first_listarg, "List Argument", :default => []
         p.option :second_listarg, "List Argument", :default => []
       end
@@ -130,7 +130,7 @@ describe Parser do
 
   describe "default settings" do
     it "should set default settings on all options" do
-      parser = Parser.new(:optional => true) do |p|
+      parser = Micro::Optparse::Parser.new(:optional => true) do |p|
         p.option :foo, "foo argument"
         p.option :bar, "bar argument"
       end
@@ -140,7 +140,7 @@ describe Parser do
     end
 
     it "should allow to overwrite default settings" do
-      parser = Parser.new(:default => "Bar") do |p|
+      parser = Micro::Optparse::Parser.new(:default => "Bar") do |p|
         p.option :foo, "foo argument", :default => "Foo"
         p.option :bar, "bar argument"
       end

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,4 +1,4 @@
-require "micro-optparse"
+require_relative "../lib/micro-optparse"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |c|

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -1,5 +1,11 @@
 require "micro-optparse"
 
+RSpec.configure do |config|
+  config.expect_with :rspec do |c|
+    c.syntax = [:should, :expect]
+  end
+end
+
 describe Parser do
   before(:all) do
     @evolutionary_algorithm_parser = Parser.new do |p|

--- a/spec/programs/eating.rb
+++ b/spec/programs/eating.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require_relative "../../lib/micro-optparse"
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.version = "EatingScript 1.0 (c) Florian Pilz 2011"
   p.banner = "This is a banner"
   p.option :verbose, "Switch on verbosity"

--- a/spec/programs/eating.rb
+++ b/spec/programs/eating.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.version = "EatingScript 1.0 (c) Florian Pilz 2011"

--- a/spec/programs/empty.rb
+++ b/spec/programs/empty.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require_relative "../../lib/micro-optparse"
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
 end.process!
 
 options.each_pair do |key, value|

--- a/spec/programs/empty.rb
+++ b/spec/programs/empty.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
 end.process!

--- a/spec/programs/noshort.rb
+++ b/spec/programs/noshort.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require_relative "../../lib/micro-optparse"
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.option :foo, "Option 1", :default => "String", :no_short => true
   p.option :bar, "Option 2", :default => "String"
 end.process!

--- a/spec/programs/noshort.rb
+++ b/spec/programs/noshort.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.option :foo, "Option 1", :default => "String", :no_short => true

--- a/spec/programs/short.rb
+++ b/spec/programs/short.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require_relative "../../lib/micro-optparse"
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.option :abc, "Option 1", :default => "String"
   p.option :bca, "Option 2", :default => "String"
   p.option :cab, "Option 3", :default => "String"

--- a/spec/programs/short.rb
+++ b/spec/programs/short.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.option :abc, "Option 1", :default => "String"

--- a/spec/programs/version.rb
+++ b/spec/programs/version.rb
@@ -1,7 +1,7 @@
 require "rubygems"
 require_relative "../../lib/micro-optparse"
 
-options = Parser.new do |p|
+options = Micro::Optparse::Parser.new do |p|
   p.version = "VersionScript 0.0 (c) Florian Pilz 2011"
 end.process!
 

--- a/spec/programs/version.rb
+++ b/spec/programs/version.rb
@@ -1,5 +1,5 @@
 require "rubygems"
-require "micro-optparse"
+require_relative "../../lib/micro-optparse"
 
 options = Parser.new do |p|
   p.version = "VersionScript 0.0 (c) Florian Pilz 2011"


### PR DESCRIPTION
Using Scout APM which uses [Parser](https://github.com/whitequark/parser) which isn't great, but assumes `Parser` can be a top-level module, and that conflicts with this gem which was using `Parser` as a top-level Class.

It just seemed better to wrap the `Parser` class here into the `Micro::Optparse` namespace to make sure it wouldn't conflict with anything.
